### PR TITLE
Cap on 'h' causing github linking to break

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,7 +1,7 @@
 <div class="social">
 	<h4>
     {{ if .Site.Social.Github }}
-	  <a href="http://github.com/{{ .Site.Social.GitHub }}"><i class="fa fa-github"></i></a>
+	  <a href="http://github.com/{{ .Site.Social.Github }}"><i class="fa fa-github"></i></a>
     {{ end }}
 
     {{ if .Site.Social.Email }}


### PR DESCRIPTION
GitHub, rather than Github meant that profile github link wasn't generating correctly. 
