### PR TITLE
Fixing Favicon Link

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="author" content="{{ .Site.Author }}" />
     {{ if .Site.Params.description }}<meta name="description" content="{{ .Site.Params.description }}">{{ end }}
-    <link rel="favicon" href="{{ .Site.BaseURL }}img/favicon.ico">
+    <link rel="shortcut icon" type="image/x-icon" href="{{ .Site.BaseURL }}img/favicon.ico">
     <title>
     {{- $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" -}}
     {{- if eq $url "/" -}}


### PR DESCRIPTION
The existing favicon link did not work for me. After googling around I found a syntax that pulled the correct favicon.ico and updated it immediately.
