### PR TITLE
Archetype fix

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,4 +1,4 @@
-+++ 
++++
 title = ""
 description = ""
 tags = []


### PR DESCRIPTION
Removed trailing white-space from archetypes/default.md, which was
causing issues when building. See spf13/hugo#2258 for details on this.