### PR TITLE
make sure that tags don't overlap on small screens

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -160,6 +160,10 @@ html, body {
 .blog-title{
   padding-top: 2px;
 }
+.label {
+    display: inline-block;
+    margin-bottom: 5px;
+}
 .related-posts h4 {
   text-align: center;
 }


### PR DESCRIPTION
On small screen, e.g. on mobile devices the tags overlap, see:

![hugo1](https://user-images.githubusercontent.com/1589737/27493763-483608e2-584b-11e7-8274-8a7fd4d6d9cc.png)

with the changes of this PR the issue is solved, see:

![hugo2](https://user-images.githubusercontent.com/1589737/27493767-522ee8f0-584b-11e7-98a0-419b04ae2ef0.png)
