### PR TITLE
fixed improper capitalization of Params.Social

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -19,7 +19,7 @@ theme = "hugo-sustain"
   custom_css = []
   custom_js  = []
 
-[params.social]
+[params.Social]
   Github        = "username"
   Email         = "email@example.com"
   Twitter       = "username"


### PR DESCRIPTION
index.html and social.html refer to social parameters by Params.Social, but config.toml in the exampleSite has Params.Social as Params.social (lower case "s"), this prevents URIs from being assembled correctly.

Also it seems like I don't have push permissions to the original repo.