### PR TITLE
Fix author param reference

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="author" content="{{ .Site.Author }}" />
+    <meta name="author" content="{{ .Site.Params.Author }}" />
     {{ if .Site.Params.description }}<meta name="description" content="{{ .Site.Params.description }}">{{ end }}
     <link rel="shortcut icon" type="image/x-icon" href="{{ .Site.BaseURL }}img/favicon.ico">
     <title>


### PR DESCRIPTION
The example config.toml stores the 'author' variable under [params] but the head.html partial looks for it in the root of config.toml.