### PR TITLE
Add a forward slash to the favicon link to fix it loading properly

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="author" content="{{ .Site.Params.Author }}">
-    <link rel="shortcut icon" type="image/x-icon" href="{{ .Site.BaseURL }}/img/favicon.ico">
+    <link rel="shortcut icon" type="image/x-icon" href="{{ .Site.BaseURL }}/img/favicon.ico?">
     <title>{{ if .IsHome }}{{ else }}{{ if .Title }}{{ .Title }} | {{ end }}{{ end }}{{ .Site.Title }}</title>
     <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl" crossorigin="anonymous">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -21,13 +21,12 @@
 			<script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
 		<![endif]-->` | safeHTML }}
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.googleAnalytics }}"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
-      gtag('config', '{{ .Site.googleAnalytics }}');
+      gtag('config', '{{ .Site.GoogleAnalytics }}');
     </script>
   </head>
   <body>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,7 +14,7 @@
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,200bold,400old">
     {{ range .Site.Params.custom_css }}
-      <link rel="stylesheet" href="{{ $.Site.BaseURL}}{{ . }}">
+      <link rel="stylesheet" href="{{ . }}">
     {{ end }}
     {{ `<!--[if lt IE 9]>
 			<script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -20,8 +20,15 @@
 			<script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
 			<script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
 		<![endif]-->` | safeHTML }}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.googleAnalytics }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-    {{- template "_internal/google_analytics_async.html" . }}
+      gtag('config', '{{ .Site.googleAnalytics }}');
+    </script>
   </head>
   <body>
     <div id="content">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="author" content="{{ .Site.Params.Author }}">
-    <link rel="shortcut icon" type="image/x-icon" href="{{ .Site.BaseURL }}img/favicon.ico">
+    <link rel="shortcut icon" type="image/x-icon" href="{{ .Site.BaseURL }}/img/favicon.ico">
     <title>{{ if .IsHome }}{{ else }}{{ if .Title }}{{ .Title }} | {{ end }}{{ end }}{{ .Site.Title }}</title>
     <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl" crossorigin="anonymous">

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -25,7 +25,7 @@
     {{ end }}
 
     {{ with .Site.Params.Social.Hashnode }}
-      <li><a href="https://@{{ . }}.hashnode.dev"><i class="fa fa-blog"></i></a></li>
+      <li><a href="https://@{{ . }}.hashnode.dev"><i class="fa fa-rss"></i></a></li>
     {{ end }}
 
     {{ with .Site.Params.Social.Telegram }}

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -24,6 +24,10 @@
       <li><a href="https://medium.com/@{{ . }}"><i class="fa fa-medium"></i></a></li>
     {{ end }}
 
+    {{ with .Site.Params.Social.Hashnode }}
+      <li><a href="https://@{{ . }}.hashnode.dev"><i class="fa fa-blog"></i></a></li>
+    {{ end }}
+
     {{ with .Site.Params.Social.Telegram }}
       <li><a href="https://telegram.me/{{ . }}"><i class="fa fa-telegram"></i></a></li>
     {{ end }}


### PR DESCRIPTION
The favicon link is broken and will not load.  Adding this forward slash fixes the link and allows the browser to open the image