### PR TITLE
Fix deprecated template (2)

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -21,7 +21,7 @@
 			<script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
 		<![endif]-->` | safeHTML }}
 
-    {{- template "_internal/google_analytics_async.html" . }}
+    {{- template "_internal/google_analytics.html" . }}
   </head>
   <body>
     <div id="content">


### PR DESCRIPTION
See https://discourse.gohugo.io/t/build-error-on-v0-125-2-calling-internal-template-internal-google-analytics-async-html/49410